### PR TITLE
Changed 2nd option for connecting to oracle w/out a Z drive file

### DIFF
--- a/code/data_dl.R
+++ b/code/data_dl.R
@@ -3,12 +3,12 @@ if (file.exists("Z:/Projects/ConnectToOracle.R")) {
   # This has a specific username and password because I DONT want people to have access to this!
   source("Z:/Projects/ConnectToOracle.R")
 } else {
-  username <- getPass::getPass(msg = "Enter your ORACLE Username: ")
-  password <- getPass::getPass(msg = "Enter your ORACLE Password: ")
-  channel <- RODBC::odbcConnect(dsn = paste(schema), 
-                                                 uid = paste(username), 
-                                                 pwd = paste(password),
-                                                 believeNRows = FALSE)
+  # For those without a ConnectToOracle file
+  channel <- odbcConnect(dsn = "AFSC", 
+                         uid = rstudioapi::showPrompt(title = "Username", 
+                                                      message = "Oracle Username", default = ""), 
+                         pwd = rstudioapi::askForPassword("Enter Password"),
+                         believeNRows = FALSE)
 }
 
 # DOWNLOAD CPUE and BIOMASS EST ------------------------------------------------


### PR DESCRIPTION
I was having problems connecting or Oracle via the data_dl.R script, so I updated the 2nd method (where you have to enter your username and password each time). It works for me, so hopefully it'll work for others.